### PR TITLE
fix(deps): update lodash to mitigate moderate CVE-2025-13465

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@jsdevtools/ono": "^7.1.3",
     "@types/json-schema": "^7.0.15",
     "js-yaml": "^4.1.1",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.23"
   },
   "release": {
     "branches": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -334,7 +334,7 @@ __metadata:
     globals: "npm:^15.13.0"
     js-yaml: "npm:^4.1.1"
     jsdom: "npm:^25.0.1"
-    lodash: "npm:^4.17.21"
+    lodash: "npm:^4.17.23"
     prettier: "npm:^3.4.2"
     rimraf: "npm:^6.0.1"
     typescript: "npm:^5.7.2"
@@ -2840,10 +2840,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.21":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
+"lodash@npm:^4.17.23":
+  version: 4.17.23
+  resolution: "lodash@npm:4.17.23"
+  checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- needed to pass audits

https://github.com/lodash/lodash/security/advisories/GHSA-xxjr-mmjv-4gpg